### PR TITLE
💄画像上に文字追加

### DIFF
--- a/src/components/About/AboutIntroduction/index.tsx
+++ b/src/components/About/AboutIntroduction/index.tsx
@@ -6,9 +6,25 @@ import type { VFC } from 'react';
 export const AboutIntroduction: VFC = () => {
   return (
     <div>
-      <div className='w-screen block'>
+      <figure className='relative w-full text-xs  sm:text-base '>
         <img src='/main-visual1.png' alt='サイト概要のメイン画像' className='w-full' />
-      </div>
+        <figcaption className='absolute text-white bottom-2 right-1 sm:bottom-4 sm:right-2 md:bottom-8  lg:bottom-12 lg:right-8 z-index-2  '>
+          <div className='hidden sm:block'>
+            <p className='font-black text-md sm:text-2xl md:text-3xl lg:text-4xl '>
+              あなたの暮らしはここから始まる
+            </p>
+            <p className='font-bold pt-2 lg:pt-4 lg:text-xl xl:text-2xl '>
+              自治体ごとに公表された住宅支援やお試し移住体験から
+            </p>
+            <p className='font-bold pt-2 lg:pt-4 lg:text-xl xl:text-2xl '>
+              条件にあった町を覗いてみませんか？
+            </p>
+            <p className='font-bold pt-2 lg:pt-4 lg:text-xl xl:text-2xl '>
+              あなたにあった居場所がきっと見つかるはずです
+            </p>
+          </div>
+        </figcaption>
+      </figure>
       {/* Reco Spoとは */}
       <div className='container mx-auto max-w-[1080px]'>
         <h1 className='flex justify-center text-2xl my-10 sm:my-14 sm:text-4xl'>Reco Spoとは</h1>

--- a/src/components/About/AboutIntroduction/index.tsx
+++ b/src/components/About/AboutIntroduction/index.tsx
@@ -28,7 +28,7 @@ export const AboutIntroduction: VFC = () => {
       {/* Reco Spoとは */}
       <div className='container mx-auto max-w-[1080px]'>
         <h1 className='flex justify-center text-2xl my-10 sm:my-14 sm:text-4xl'>Reco Spoとは</h1>
-        <div className='text-sm sm:text-xl sm:pl-24'>
+        <div className='text-sm sm:text-xl'>
           <p className='mb-4 px-10'>
             将来的に田舎暮らしに憧れを持っているが、日本各地それぞれの土地の魅力は様々。
           </p>

--- a/src/components/About/AboutIntroduction/index.tsx
+++ b/src/components/About/AboutIntroduction/index.tsx
@@ -8,9 +8,9 @@ export const AboutIntroduction: VFC = () => {
     <div>
       <figure className='relative w-full text-xs  sm:text-base '>
         <img src='/main-visual1.png' alt='サイト概要のメイン画像' className='w-full' />
-        <figcaption className='absolute text-white bottom-2 right-1 sm:bottom-4 sm:right-2 md:bottom-8  lg:bottom-12 lg:right-8 z-index-2  '>
+        <figcaption className='absolute text-white bottom-2 right-1 z-index-1 sm:bottom-4 sm:right-2 md:bottom-8 lg:bottom-12 lg:right-8 2xl:bottom-20'>
           <div className='hidden sm:block'>
-            <p className='font-black text-md sm:text-2xl md:text-3xl lg:text-4xl '>
+            <p className='font-black text-md sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl '>
               あなたの暮らしはここから始まる
             </p>
             <p className='font-bold pt-2 lg:pt-4 lg:text-xl xl:text-2xl '>


### PR DESCRIPTION
## 対応内容

メインビジュアル上に文字を追加

## 確認ページ

・トップページ

## issue

[#47](https://github.com/ukigumo-shiina3/Reco-Spo/issues/47)

## 注意点
スクショのように文字サイズを一番小さくしても見栄えが悪いため、ブレークポイント「sm」以下は文字を非表示にしています。

<img width="385" alt="スクリーンショット 2022-04-14 17 04 06" src="https://user-images.githubusercontent.com/67767613/163343340-8be567de-75e0-4e79-8af7-d8c92aed0947.png">

