### PR TITLE
admin_idに紐づいたSpotのデータを取得し編集ページへ遷移できるように修正

### DIFF
--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -34,7 +34,7 @@ export const Sidebar: VFC<Props> = (props) => {
   useEffect(() => {
     if (loginAccount.session()?.user?.id !== undefined) {
       //ここでgetSpotsEditの引数にadmin_idを渡していないのはsetAdminIdが間に合わないから
-      console.log(loginAccount.session()?.user?.id);
+      // console.log(loginAccount.session()?.user?.id);
       setAdminId(loginAccount.session()?.user?.id);
       getSpotsEdit(supabase.auth.session()?.user?.id);
     }

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -6,7 +6,6 @@ import { useCallback } from 'react';
 import { supabase } from 'src/libs/supabase';
 import { toast, Toaster } from 'react-hot-toast';
 import { useRouter } from 'next/router';
-import { getSpotsId } from 'src/hooks/useSpotIdSelect';
 import { Spot } from 'src/types/spot';
 
 type Props = {
@@ -17,12 +16,12 @@ export const Sidebar: VFC<Props> = (props) => {
   const router = useRouter();
 
   const [adminId, setAdminId] = useState<string>();
-  const [spotData, setSpotData] = useState<any[] | null>(null);
+  const [spotData, setSpotData] = useState<Spot[] | null>();
   const loginAccount = supabase.auth;
   const getSpotsEdit = useCallback(async (admin_id) => {
     // DBからスポット情報を取得　WHERE旬はareaカラムは兵庫県で絞り、admin_idカラムはadminIdで絞ってます
     const { data: spot, error } = await supabase
-      .from('spots')
+      .from<Spot>('spots')
       .select('*')
       .eq(`area`, `兵庫県`)
       .eq(`admin_id`, admin_id);
@@ -34,6 +33,7 @@ export const Sidebar: VFC<Props> = (props) => {
   // セッション情報のjsonが直ぐに取得できないことがあるので、if文でデータが取得できるまで待ってから取得
   useEffect(() => {
     if (loginAccount.session()?.user?.id !== undefined) {
+      //ここでgetSpotsEditの引数にadmin_idを渡していないのはsetAdminIdが間に合わないから
       console.log(loginAccount.session()?.user?.id);
       setAdminId(loginAccount.session()?.user?.id);
       getSpotsEdit(supabase.auth.session()?.user?.id);

--- a/src/types/spot.tsx
+++ b/src/types/spot.tsx
@@ -1,4 +1,5 @@
 export type Spot = {
+  admin_id?: string;
   id: string;
   prefecture_id: string;
   prefectures: {


### PR DESCRIPTION
UseStateはまとめるとかえっておかしくなることがわかったのでこのままにした
時々ログイン時のユーザーデータが反映されないことがあるのは今後要確認