### PR TITLE
🐛 アバター編集の有効化

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_AVATARS_BUCKET } from 'src/libs/constant';
 
 type checkFuncType = (path: string) => Promise<void> | void | null;
 
-export default function Avatar({ url, size }: { url: string | null; size: number }) {
+export default function Avatar({ url, dummyImageUrl, size }: { url: string | null, dummyImageUrl?: string | null, size: number }) {
   // const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
 
   // const downloadImage = useCallback(async (path: string) => {
@@ -34,12 +34,16 @@ export default function Avatar({ url, size }: { url: string | null; size: number
   //   }
   // }, [avatarUrl, downloadImage, url]);
 
+  if (!url) {
+    if (dummyImageUrl) {
+      return <img src={dummyImageUrl} alt="avatar" className="rounded-full mb-2" style={{ height: size, width: size }} />
+    } else {
+      return <div className='avatar no-image' style={{ height: size, width: size }} />
+    }
+  }
 
-
-  return url ? (
+  return (
     // eslint-disable-next-line jsx-a11y/alt-text
-    <img src={url} className='rounded-full mb-2' style={{ height: size, width: size }} />
-  ) : (
-    <div className='avatar no-image' style={{ height: size, width: size }} />
+    <img src={url} alt="avatar" className='rounded-full mb-2' style={{ height: size, width: size }} />
   );
 }

--- a/src/components/Button/UploadButton/UploadButton.tsx
+++ b/src/components/Button/UploadButton/UploadButton.tsx
@@ -8,8 +8,8 @@ export type UploadButtonProps = {
 
 export default function UploadButton({ loading, onUpload }: UploadButtonProps) {
   return useMemo(() => (
-    <div>
-      <label className='ml-3' htmlFor='single'>
+    <div className="flex flex-col justify-center items-center">
+      <label className="w-full py-1" htmlFor='single'>
         {loading ? '.......' : '変更'}
       </label>
       {/* <input
@@ -26,6 +26,7 @@ export default function UploadButton({ loading, onUpload }: UploadButtonProps) {
       <Input
         type='file'
         id='single'
+        className="hidden"
         style={{
           visibility: 'hidden',
         }}

--- a/src/pages/admins/index.tsx
+++ b/src/pages/admins/index.tsx
@@ -185,9 +185,6 @@ const ProfileEdit: VFC = () => {
   //   return <div>エラーが発生しました。</div>;
   // }
 
-  console.log('avatarUrl', avatarUrl);
-  console.log('avatarDownloadUrl', avatarDownloadUrl);
-
   return (
     <>
       <div className='flex bg-gray-100 h-full'>
@@ -202,9 +199,8 @@ const ProfileEdit: VFC = () => {
             })}
           >
             {/* <form> */}
-            {/* TODO: うまく動作できなかったためコメントアウト */}
-            {/* <div className='pt-5 mt-5'>
-              <div className='text-sm mt-2'>
+            <div className='pt-5 mt-5'>
+              <div className='flex flex-col justify-center items-center text-sm mt-2'>
                 {avatarUrl ? (
                   <Avatar url={avatarDownloadUrl} size={60} />
                 ) : (
@@ -216,7 +212,7 @@ const ProfileEdit: VFC = () => {
                 )}
                 <UploadButton onUpload={uploadAvatar} loading={uploading} />
               </div>
-            </div> */}
+            </div>
             <label htmlFor='prefecture' className='flex justify-start pt-10 pb-3'>
               都道府県
             </label>

--- a/src/pages/admins/index.tsx
+++ b/src/pages/admins/index.tsx
@@ -199,9 +199,9 @@ const ProfileEdit: VFC = () => {
             })}
           >
             {/* <form> */}
-            <div className='pt-5 mt-5'>
+            <div className='flex justify-start pt-5 mt-5'>
               <div className='flex flex-col justify-center items-center text-sm mt-2'>
-                <Avatar url={avatarDownloadUrl} dummyImageUrl="/icons/profile-icon.png" size={60} />
+                <Avatar url={avatarDownloadUrl} dummyImageUrl="/icons/profile-icon.png" size={80} />
                 <UploadButton onUpload={uploadAvatar} loading={uploading} />
               </div>
             </div>

--- a/src/pages/admins/index.tsx
+++ b/src/pages/admins/index.tsx
@@ -201,15 +201,7 @@ const ProfileEdit: VFC = () => {
             {/* <form> */}
             <div className='pt-5 mt-5'>
               <div className='flex flex-col justify-center items-center text-sm mt-2'>
-                {avatarUrl ? (
-                  <Avatar url={avatarDownloadUrl} size={60} />
-                ) : (
-                  <img
-                    src='/icons/profile-icon.png'
-                    alt='image'
-                    className='w-17 h-16 pr-4 rounded-full'
-                  />
-                )}
+                <Avatar url={avatarDownloadUrl} dummyImageUrl="/icons/profile-icon.png" size={60} />
                 <UploadButton onUpload={uploadAvatar} loading={uploading} />
               </div>
             </div>


### PR DESCRIPTION
## 対応内容
- 無効化にしていたアバター編集機能を有効化
- アバターが設定されていなかった場合のダミー画像の切り替え処理をAvatarコンポーネントに取り込み

## 確認ページ
- プロフィール編集ページでアバターを変更
http://localhost:3000/admins


## スクリーンショット
![スクリーンショット 2022-05-19 6 37 05](https://user-images.githubusercontent.com/15701307/169162530-0c99e9ea-226a-4b44-9fd9-7cda7793fa13.png)

