### PR TITLE
💄 認証画面のレイアウト変更

### DIFF
--- a/src/components/Admin/AdminSignin/index.tsx
+++ b/src/components/Admin/AdminSignin/index.tsx
@@ -91,63 +91,65 @@ export const AdminSignin: VFC<Props> = (props, session) => {
             alt='管理画面画像'
           />
         </div>
-        <div className='flex justify-center items-center z-10 h-screen w-full rounded overflow-hidden shadow-2xl mr-0 ml-auto my-auto lg:w-1/2 bg-gray-200'>
-          <div className='flex flex-col justify-center items-center w-full max-w-[80%] p-4 mt-14 bg-white md:mt-12 md:py-16 md:px-10 '>
+        <div className='flex justify-center items-center z-10 h-screen w-full rounded overflow-hidden shadow-2xl mr-0 ml-auto my-auto lg:w-1/2 bg-blue-50'>
+          <div className='flex flex-col w-full justify-center items-center'>
             <div className='font-bold text-2xl text-center mt-8 mb-2'>{props.title}</div>
-            <div className='m-auto max-w-full'>
-              <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
-                メールアドレス
-              </label>
-              <input
-                type='text'
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value.trim());
-                }}
-                placeholder='reco-spo@gmail.com'
-                className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 bg-gray-200 rounded-md placeholder-gray-500'
-              />
-              <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
-                パスワード
-              </label>
-              <input
-                type='text'
-                value={password}
-                onChange={(e) => {
-                  setPassword(e.target.value.trim());
-                }}
-                placeholder='test1234'
-                className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 bg-gray-200 rounded-md placeholder-gray-500'
-              />
-            </div>
+            <div className='flex flex-col justify-center items-center w-full max-w-[80%] p-4 mt-8 bg-white md:py-16 md:px-10 '>
+              <div className='m-auto max-w-full'>
+                <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
+                  メールアドレス
+                </label>
+                <input
+                  type='text'
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value.trim());
+                  }}
+                  placeholder='reco-spo@gmail.com'
+                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                />
+                <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
+                  パスワード
+                </label>
+                <input
+                  type='text'
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value.trim());
+                  }}
+                  placeholder='test1234'
+                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
+                />
+              </div>
 
-            <div className='pb-10'>
-              <div className='flex flex-col items-center'>
-                <Link href='/admins' passHref>
-                  <button
-                    onClick={handleSignin}
-                    className='px-5 py-3 mt-10 text-white bg-blue-300 rounded-lg w-[250px] sm:w-[300px]'
-                  >
-                    {props.signinButton}
-                  </button>
-                </Link>
-                <Link href='/admins' passHref>
-                  <button
-                    onClick={handleTestSignin}
-                    className='px-5 py-3 mt-2 text-white bg-green-300 rounded-lg w-[250px] sm:w-[300px]'
-                  >
-                    <div className=''>{props.testSigninButton}</div>
-                  </button>
-                </Link>
+              <div className='pb-10'>
+                <div className='flex flex-col items-center'>
+                  <Link href='/admins' passHref>
+                    <button
+                      onClick={handleSignin}
+                      className='px-5 py-3 mt-10 text-white bg-blue-300 rounded-lg w-[250px] sm:w-[300px]'
+                    >
+                      {props.signinButton}
+                    </button>
+                  </Link>
+                  <Link href='/admins' passHref>
+                    <button
+                      onClick={handleTestSignin}
+                      className='px-5 py-3 mt-2 text-white bg-green-300 rounded-lg w-[250px] sm:w-[300px]'
+                    >
+                      <div className=''>{props.testSigninButton}</div>
+                    </button>
+                  </Link>
+                </div>
+                <div className='flex flex-col items-center mt-6'>
+                  <Link href='/admins/signup' passHref>
+                    <a className='text-sm pt-2 w-[140px] '>
+                      <p className='text-indigo-700'>新規会員登録はこちら</p>
+                    </a>
+                  </Link>
+                </div>
+                <Toaster />
               </div>
-              <div className='flex flex-col items-center mt-6'>
-                <Link href='/admins/signup' passHref>
-                  <a className='text-sm pt-2 w-[140px] '>
-                    <p className='text-indigo-700'>新規会員登録はこちら</p>
-                  </a>
-                </Link>
-              </div>
-              <Toaster />
             </div>
           </div>
         </div>

--- a/src/components/Admin/AdminSignup/index.tsx
+++ b/src/components/Admin/AdminSignup/index.tsx
@@ -53,48 +53,49 @@ export const AdminSignup: VFC<Signup> = (props) => {
             alt='管理画面画像'
           />
         </div>
-
-        <div className='flex justify-center items-center z-10 h-screen w-full rounded overflow-hidden shadow-2xl mr-0 ml-auto my-auto lg:w-1/2 bg-gray-200'>
-          <div className='flex flex-col justify-center items-center w-full max-w-[80%] p-4 mt-14 bg-white md:mt-12 md:py-16 md:px-10 '>
+        <div className='flex justify-center items-center z-10 h-screen w-full rounded overflow-hidden shadow-2xl mr-0 ml-auto my-auto lg:w-1/2 bg-blue-50'>
+          <div className='flex flex-col w-full justify-center items-center'>
             <div className='font-bold text-2xl text-center mt-8 mb-2'>{props.title}</div>
-            <div className='m-auto max-w-full'>
-              <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
-                メールアドレス
-              </label>
-              <input
-                type='text'
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value.trim());
-                }}
-                placeholder='reco-spo@gmail.com'
-                className='w-[280px] sm:w-[300px] md:w-[380px] p-2 bg-gray-200 max-w-full rounded-md placeholder-gray-500'
-              />
-              <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
-                パスワード
-              </label>
-              <input
-                type='text'
-                value={password}
-                onChange={(e) => {
-                  setPassword(e.target.value.trim());
-                }}
-                placeholder='test1234'
-                className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 bg-gray-200 rounded-md placeholder-gray-500'
-              />
-            </div>
+            <div className='flex flex-col justify-center items-center w-full max-w-[80%] p-4 mt-8 bg-white md:py-16 md:px-10 '>
+              <div className='m-auto max-w-full'>
+                <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
+                  メールアドレス
+                </label>
+                <input
+                  type='text'
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value.trim());
+                  }}
+                  placeholder='reco-spo@gmail.com'
+                  className='w-[280px] sm:w-[300px] md:w-[380px] p-2 border-2 max-w-full rounded-md placeholder-gray-500'
+                />
+                <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
+                  パスワード
+                </label>
+                <input
+                  type='text'
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value.trim());
+                  }}
+                  placeholder='test1234'
+                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 border-2 rounded-md placeholder-gray-500'
+                />
+              </div>
 
-            <div className='flex justify-center  pl-4 pb-10'>
-              <Link href='/admins' passHref>
-                <button
-                  onClick={handleSignup}
-                  className='px-5 py-3 mt-10 text-white bg-blue-300 rounded-lg w-[200px] sm:w-[220px]'
-                >
-                  {props.button}
-                </button>
-              </Link>
+              <div className='flex justify-center pl-4 pb-10'>
+                <Link href='/admins' passHref>
+                  <button
+                    onClick={handleSignup}
+                    className='px-5 py-3 mt-10 text-white bg-blue-300 rounded-lg w-[200px] sm:w-[220px]'
+                  >
+                    {props.button}
+                  </button>
+                </Link>
+              </div>
+              <Toaster />
             </div>
-            <Toaster />
           </div>
         </div>
       </AdminAuthLayout>


### PR DESCRIPTION
## 対応内容
- カードから「ログイン」のテキストを出した
- 背景色とプレースホルダーの色変更
- 余白の調整

## 確認ページ
- ログイン
- 新規登録ページ
