### PR TITLE
💄 管理画面をリメイク用にレイアウト修正

### DIFF
--- a/src/components/Button/UploadButton/SpotUploadButton.tsx
+++ b/src/components/Button/UploadButton/SpotUploadButton.tsx
@@ -38,22 +38,22 @@ const dropzoneChildren = (status: DropzoneStatus, theme: MantineTheme) => (
     position='center'
     spacing='sm'
     direction='column'
-    style={{ minHeight: 120, pointerEvents: 'none' }}
+    style={{ minHeight: 80, pointerEvents: 'none' }}
   >
-    <div className='flex border-2 border-red-600 rounded-lg p-2 mt-6'>
+    <div className='flex border-2 border-red-600 rounded-lg p-2 mt-2'>
       <ImageUploadIcon
         status={status}
         style={{ color: getIconColor(status, theme) }}
         size={20}
         color='red'
       />
-      <Text size='sm' color='red' weight={700} inline mt={3} ml={3}>
+      <Text size='sm' color='red' weight={600} inline mt={3} ml={3}>
         画像を選択する
       </Text>
     </div>
     {console.log(status)}
     <div>
-      <Text size='sm' color='blue' weight={700} inline>
+      <Text size='sm' color='blue' weight={600} inline>
         またはドラッグ&ドロップ
       </Text>
     </div>
@@ -69,7 +69,7 @@ export default function SpotUploadButton(props: SpotUploadButtonProps) {
           {props.loading ? (
             '.......'
           ) : (
-            <div className='mt-5'>
+            <div className='mt-2'>
               <Dropzone
                 onDrop={props.onUpload}
                 onReject={(files) => console.log('rejected files', files)}

--- a/src/components/Layout/AdminInfoLayout/index.tsx
+++ b/src/components/Layout/AdminInfoLayout/index.tsx
@@ -139,7 +139,9 @@ export const AdminInfoLayout: VFC<Props> = (props) => {
         </Transition>
 
         <div className='flex justify-center items-center h-full bg-blue-50'>
-          <div className='flex flex-col w-full justify-center items-center'>{props.children}</div>
+          <div className='flex flex-col w-full justify-center items-center h-full'>
+            {props.children}
+          </div>
         </div>
       </>
     ),

--- a/src/components/Spot/SpotImage/index.tsx
+++ b/src/components/Spot/SpotImage/index.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { useEffect, useState } from 'react';
-import { supabase } from 'src/libs/supabase';
-import { DEFAULT_SPOTS_BUCKET } from 'src/libs/regular';
+import { useState } from 'react';
 
 export default function SpotImage({
   url,
@@ -20,7 +18,7 @@ export default function SpotImage({
         <img
           src={dummyImageUrl}
           alt='spot-image'
-          className='m-auto mt-1.5 w-8 h-8'
+          className='m-auto mt-3 w-8 h-8'
           style={{ height: size, width: size }}
         />
       );

--- a/src/pages/admins/index.tsx
+++ b/src/pages/admins/index.tsx
@@ -58,81 +58,75 @@ const ProfileEdit: VFC = () => {
   return (
     <>
       <AdminInfoLayout>
-        <div className='h-full flex flex-col justify-center items-center'>
-          <h1 className='font-bold text-3xl mt-12'>プロフィール編集</h1>
-          <div className='h-full my-10 px-12 overflow-hidden shadow-lg bg-white'>
-            <form
-              onSubmit={form.onSubmit((values) => {
-                console.log(values);
-                update({ id: admins.id, ...form.values });
-              })}
-            >
-              {/* <form> */}
-              <div className='flex justify-start pt-5 mt-5'>
-                <div className='flex flex-col justify-center items-center text-sm mt-2'>
-                  <Avatar
-                    url={avatarDownloadUrl}
-                    dummyImageUrl='/icons/profile-icon.png'
-                    size={80}
-                  />
-                  <UploadButton onUpload={uploadAvatar} loading={uploading} />
-                </div>
+        <h1 className='font-bold text-3xl mt-12'>プロフィール編集</h1>
+        <div className='h-full my-10 px-12 overflow-hidden shadow-lg bg-white'>
+          <form
+            onSubmit={form.onSubmit((values) => {
+              console.log(values);
+              update({ id: admins.id, ...form.values });
+            })}
+          >
+            {/* <form> */}
+            <div className='flex justify-start pt-5 mt-5'>
+              <div className='flex flex-col justify-center items-center text-sm mt-2'>
+                <Avatar url={avatarDownloadUrl} dummyImageUrl='/icons/profile-icon.png' size={80} />
+                <UploadButton onUpload={uploadAvatar} loading={uploading} />
               </div>
-              <label htmlFor='prefecture' className='flex justify-start pt-10 pb-3'>
-                都道府県
-              </label>
-              <TextInput
-                required
-                id='prefecture'
-                placeholder='山形県'
-                classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
-                {...form.getInputProps('prefecture')}
-              />
-              <label htmlFor='group' className='flex justify-start pt-10 pb-3'>
-                自治体
-              </label>
-              <TextInput
-                required
-                id='group'
-                placeholder='遊佐町役場'
-                classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
-                {...form.getInputProps('group')}
-              />
-              <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
-                メールアドレス
-              </label>
-              <TextInput
-                required
-                id='email'
-                autoComplete='email'
-                placeholder='reco-spo@gmail.com'
-                classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
-                {...form.getInputProps('email')}
-              />
-              <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
-                パスワード
-              </label>
-              <TextInput
-                required
-                id='password'
-                type='password'
-                autoComplete='current-password'
-                placeholder='test1234'
-                classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
-                {...form.getInputProps('password')}
-              />
+            </div>
+            <label htmlFor='prefecture' className='flex justify-start pt-10 pb-3'>
+              都道府県
+            </label>
+            <TextInput
+              required
+              id='prefecture'
+              placeholder='山形県'
+              classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
+              {...form.getInputProps('prefecture')}
+            />
+            <label htmlFor='group' className='flex justify-start pt-10 pb-3'>
+              自治体
+            </label>
+            <TextInput
+              required
+              id='group'
+              placeholder='遊佐町役場'
+              classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
+              {...form.getInputProps('group')}
+            />
+            <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
+              メールアドレス
+            </label>
+            <TextInput
+              required
+              id='email'
+              autoComplete='email'
+              placeholder='reco-spo@gmail.com'
+              classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
+              {...form.getInputProps('email')}
+            />
+            <label htmlFor='password' className='flex justify-start pt-10 pb-3'>
+              パスワード
+            </label>
+            <TextInput
+              required
+              id='password'
+              type='password'
+              autoComplete='current-password'
+              placeholder='test1234'
+              classNames={{ input: 'w-64 sm:w-96 p-2 rounded-l-md' }}
+              {...form.getInputProps('password')}
+            />
 
-              <div className='text-center pb-10'>
-                <Button
-                  type='submit'
-                  classNames={{ root: 'px-4 py-2 mt-10 mx-6 text-white bg-blue-300 rounded-lg' }}
-                >
-                  変更
-                </Button>
-              </div>
-            </form>
-            <Toaster />
-          </div>
+            <div className='text-center pb-10'>
+              <Button
+                type='submit'
+                classNames={{ root: 'px-4 py-2 mt-10 mx-6 text-white bg-blue-300 rounded-lg' }}
+              >
+                変更
+              </Button>
+            </div>
+          </form>
+          <Toaster />
         </div>
       </AdminInfoLayout>
     </>

--- a/src/pages/admins/spots/[id]/edit/index.tsx
+++ b/src/pages/admins/spots/[id]/edit/index.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @next/next/no-img-element */
 import { useEffect, useState } from 'react';
-import { Sidebar } from 'src/components/Layout/Sidebar';
 import { supabase } from 'src/libs/supabase';
 import { useCallback } from 'react';
 import { toast, Toaster } from 'react-hot-toast';
@@ -21,6 +20,7 @@ import { getSystemsCreatedAt } from 'src/hooks/useSystemssCreatedAtSelect';
 import { SystemsCreatedAt } from 'src/types/systemsCreatedAt';
 import { useSpotImage } from 'src/hooks/useSpotImage';
 import SpotImage from 'src/components/Spot/SpotImage';
+import { AdminInfoLayout } from 'src/components/Layout/AdminInfoLayout';
 
 const user = supabase.auth.user();
 
@@ -104,27 +104,6 @@ const SpotsEdit: NextPage<Spot> = () => {
     }
   }, []);
 
-  // const downloadImage = useCallback(async (path: string) => {
-  //   try {
-  //     const { data, error } = await supabase.storage.from('admins').download(path);
-  //     if (!data) {
-  //       return;
-  //     }
-  //     if (error) {
-  //       throw error;
-  //     }
-
-  //     let reader = new FileReader();
-  //     reader.readAsDataURL(data); // Blob を base64 へ変換し onload を呼び出します
-
-  //     reader.onload = () => {
-  //       setAvatarImage(reader.result as string);
-  //     };
-  //   } catch (error) {
-  //     console.log('Error downloading image: ', error.message);
-  //   }
-  // }, []);
-
   const fetchPrefecturesCreatedAt = useCallback(async () => {
     try {
       const data = await getPrefecturesCreatedAt();
@@ -170,13 +149,6 @@ const SpotsEdit: NextPage<Spot> = () => {
     },
     [setFiles],
   );
-
-  // 画像のURL化
-  // const getImageUrl = new Blob([spotEdit.image_url], { type: 'text/plain' });
-  //   useEffect(() => {
-  //     setChangeImageUrl(URL.createObjectURL(Blob));
-  // });
-  // }, [spotEdit.image_url];
 
   const handleSpotEdit = useCallback(async () => {
     setUploading(true);
@@ -269,30 +241,27 @@ const SpotsEdit: NextPage<Spot> = () => {
   if (user) {
     return (
       <>
-        <div className='flex bg-gray-100 h-full'>
-          <Sidebar />
-          <div className='bg-gray-200 h-full ml-auto mr-auto my-20 px-6 sm:px-24 overflow-hidden shadow-lg '>
-            <h1 className='text-3xl mt-24'>スポット編集</h1>
-            <br />
-            {spot != null && getSpotIndex !== undefined ? (
-              <Select
-                label='編集するスポットを選択してください'
-                value={spotIndex}
-                onChange={setSpotIndex}
-                data={getSpotIndex}
-              />
-            ) : null}
-            <br />
+        <AdminInfoLayout>
+          <h1 className='text-3xl mt-24 pt-12'>スポット編集</h1>
+          <div className='h-full my-10 px-6 sm:px-12 md:px-16 overflow-hidden shadow-lg bg-white'>
+            {/* 編集するスポットのセレクトボックス */}
+            <div className='mt-12'>
+              {spot != null && getSpotIndex !== undefined ? (
+                <Select
+                  label='編集するスポットを選択してください'
+                  value={spotIndex}
+                  onChange={setSpotIndex}
+                  data={getSpotIndex}
+                />
+              ) : null}
+            </div>
             {/* スポット画像 */}
-            <h2 className='flex mt-5'>
-              スポット画像<p className=''>(最大5枚)</p>
-            </h2>
-            <div className='flex flex-wrap items-end mt-6'>
+            <h2 className='flex mt-8'>スポット画像(最大5枚)</h2>
+            <div className='flex flex-wrap items-end'>
               <div className='flex flex-wrap gap-2 mt-5 sm:gap-6'>
-                {/* <form> */}
                 <div className='flex justify-start'>
-                  <div className='flex flex-col justify-center items-center text-sm mt-2'>
-                    <div className='bg-white h-12 w-12'>
+                  <div className='flex flex-wrap gap-2 mt-5 sm:gap-6'>
+                    <div className='bg-white w-16 h-16 border-2 border-gray-400'>
                       <SpotImage
                         url={spotDownloadUrl}
                         dummyImageUrl='/icons/camera-icon.png'
@@ -318,157 +287,154 @@ const SpotsEdit: NextPage<Spot> = () => {
             <SpotUploadButton onUpload={handleDrop} loading={uploading} />
             {/* スポット情報 */}
             <div>
-              <h2 className='mt-10 '>スポット情報</h2>
-              <div className='mt-10 text-xs'>
-                <div className='mb-5'>
-                  <label htmlFor='name'>スポット名</label>
-                  {console.log('スポット', spot)}
-                  {spot ? (
-                    <input
-                      value={spotEdit.name}
-                      onChange={(e) => {
-                        setSpotEdit({ ...spotEdit, name: e.target.value.trim() });
-                      }}
-                      className='w-full p-2 rounded-md'
-                    />
-                  ) : null}
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='title'>スポットタイトル</label>
-                  {spot ? (
-                    <input
-                      type='text'
-                      value={spotEdit.title}
-                      onChange={(e) => {
-                        setSpotEdit({ ...spotEdit, title: e.target.value.trim() });
-                      }}
-                      className='w-full p-2 rounded-md'
-                    />
-                  ) : null}
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='prefectures_name'>都道府県名</label>
-                  {prefecturesCreatedAt.length == 0 ? null : (
-                    <div>
-                      <select
-                        value={spotEdit.prefecture_id}
+              <h2 className='mt-10'>スポット情報</h2>
+              <div className='text-xs'>
+                <div className='flex gap-8'>
+                  <div className='mb-4'>
+                    <label htmlFor='name' className='flex justify-start pt-10 pb-3'>
+                      スポット名
+                    </label>
+                    {console.log('スポット', spot)}
+                    {spot ? (
+                      <input
+                        value={spotEdit.name}
                         onChange={(e) => {
-                          setSpotEdit({ ...spotEdit, prefecture_id: e.target.value.trim() });
+                          setSpotEdit({ ...spotEdit, name: e.target.value.trim() });
                         }}
-                        className='w-full p-2 rounded-md'
+                        className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                      />
+                    ) : null}
+                  </div>
+                  <div className='mb-4'>
+                    <label htmlFor='title' className='flex justify-start pt-10 pb-3'>
+                      スポットタイトル
+                    </label>
+                    {spot ? (
+                      <input
+                        type='text'
+                        value={spotEdit.title}
+                        onChange={(e) => {
+                          setSpotEdit({ ...spotEdit, title: e.target.value.trim() });
+                        }}
+                        className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                      />
+                    ) : null}
+                  </div>
+                </div>
+                <div className='flex gap-8'>
+                  <div className='mb-4'>
+                    <label htmlFor='prefectures_name' className='flex justify-start pt-10 pb-3'>
+                      都道府県名
+                    </label>
+                    {prefecturesCreatedAt.length == 0 ? null : (
+                      <div>
+                        <select
+                          value={spotEdit.prefecture_id}
+                          onChange={(e) => {
+                            setSpotEdit({ ...spotEdit, prefecture_id: e.target.value.trim() });
+                          }}
+                          className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                        >
+                          <option value='prefectures_select'>都道府県を選択</option>
+                          {prefecturesCreatedAt.map((value, index) => (
+                            <option
+                              key={index}
+                              value={value['prefectures_index']}
+                              selected={value['prefectures_index'] === spotEdit.prefecture_id}
+                            >
+                              {value['prefectures_name']}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
+                  </div>
+                  <div className='mb-4'>
+                    <label htmlFor='system' className='flex justify-start pt-10 pb-3'>
+                      制度名
+                    </label>
+                    {systemsCreatedAt.length == 0 ? null : (
+                      <select
+                        value={spotEdit.system_id}
+                        onChange={(e) => {
+                          setSpotEdit({ ...spotEdit, system_id: e.target.value.trim() });
+                        }}
+                        className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
                       >
-                        <option value='prefectures_select'>都道府県を選択</option>
-                        {prefecturesCreatedAt.map((value, index) => (
+                        <option value='systems_select'>制度を選択</option>
+                        {systemsCreatedAt.map((value, index) => (
                           <option
                             key={index}
-                            value={value['prefectures_index']}
-                            selected={value['prefectures_index'] === spotEdit.prefecture_id}
+                            value={value['systems_index']}
+                            selected={value['systems_index'] === spotEdit.system_id}
                           >
-                            {value['prefectures_name']}
+                            {value['systems_name']}
                           </option>
                         ))}
                       </select>
-                    </div>
-                  )}
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='system'>制度名</label>
-                  {systemsCreatedAt.length == 0 ? null : (
-                    <select
-                      value={spotEdit.system_id}
-                      onChange={(e) => {
-                        setSpotEdit({ ...spotEdit, system_id: e.target.value.trim() });
-                      }}
-                      className='w-full p-2 rounded-md'
-                    >
-                      <option value='systems_select'>制度を選択</option>
-                      {systemsCreatedAt.map((value, index) => (
-                        <option
-                          key={index}
-                          value={value['systems_index']}
-                          selected={value['systems_index'] === spotEdit.system_id}
-                        >
-                          {value['systems_name']}
-                        </option>
-                      ))}
-                    </select>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
             {/* スポット説明 */}
             <h2 className='mt-10'>スポット説明</h2>
-            <div className='mt-10 text-xs'>
-              <div className='mb-5'>
-                <label htmlFor='appeal'>アピールポイント</label>
+            <div className='text-xs'>
+              <div className='mb-4'>
+                <label htmlFor='appeal' className='flex justify-start pt-10 pb-3'>
+                  アピールポイント
+                </label>
                 {spot ? (
                   <textarea
                     value={spotEdit.appeal}
                     onChange={(e) => {
                       setSpotEdit({ ...spotEdit, appeal: e.target.value.trim() });
                     }}
-                    className='w-full h-24  p-2 rounded-md'
+                    className='w-full h-24 p-2 rounded-md border-2 placeholder-gray-500'
                   />
                 ) : null}
               </div>
             </div>
             {/* スポット詳細 */}
             <h2 className='mt-10'>スポット詳細</h2>
-            <div className='mt-10 text-xs'>
-              <div className='mb-5'>
-                <label htmlFor='area'>物件所在地</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.area}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, area: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
+            <div className='text-xs'>
+              <div className='flex gap-8'>
+                <div className='mb-4'>
+                  <label htmlFor='area' className='flex justify-start pt-10 pb-3'>
+                    物件所在地
+                  </label>
+                  {spot ? (
+                    <input
+                      type='text'
+                      value={spotEdit.area}
+                      onChange={(e) => {
+                        setSpotEdit({ ...spotEdit, area: e.target.value.trim() });
+                      }}
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  ) : null}
+                </div>
+
+                <div className='mb-4'>
+                  <label htmlFor='usage_fee' className='flex justify-start pt-10 pb-3'>
+                    利用料金
+                  </label>
+                  {spot ? (
+                    <input
+                      type='text'
+                      value={spotEdit.usage_fee}
+                      onChange={(e) => {
+                        setSpotEdit({ ...spotEdit, usage_fee: e.target.value.trim() });
+                      }}
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  ) : null}
+                </div>
               </div>
-              <div className='mb-5'>
-                <label htmlFor='スポット画像'>物件関連リンク</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.link}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, link: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='スポット画像'>対象者</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.target_person}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, target_person: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='スポット画像'>利用料金</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.usage_fee}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, usage_fee: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='スポット画像'>利用期間</label>
+              <div className='mb-4'>
+                <label htmlFor='term' className='flex justify-start pt-10 pb-3'>
+                  利用期間
+                </label>
                 {spot ? (
                   <input
                     type='text'
@@ -476,68 +442,50 @@ const SpotsEdit: NextPage<Spot> = () => {
                     onChange={(e) => {
                       setSpotEdit({ ...spotEdit, term: e.target.value.trim() });
                     }}
-                    className='w-full p-2 rounded-md'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
                   />
                 ) : null}
               </div>
             </div>
             {/* お問い合わせ */}
             <h2 className='mt-10'>お問い合わせ先</h2>
-            <div className='mt-10 text-xs'>
-              <div className='mb-5'>
-                <label htmlFor='postal_code'>郵便番号</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.postal_code}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, postal_code: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
+            <div className='text-xs'>
+              <div className='flex gap-8'>
+                <div className='mb-4'>
+                  <label htmlFor='manager' className='flex justify-start pt-10 pb-3'>
+                    担当者
+                  </label>
+                  {spot ? (
+                    <input
+                      type='text'
+                      value={spotEdit.manager}
+                      onChange={(e) => {
+                        setSpotEdit({ ...spotEdit, manager: e.target.value.trim() });
+                      }}
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  ) : null}
+                </div>
+                <div className='mb-4'>
+                  <label htmlFor='tel' className='flex justify-start pt-10 pb-3'>
+                    電話番号
+                  </label>
+                  {spot ? (
+                    <input
+                      type='text'
+                      value={spotEdit.tel}
+                      onChange={(e) => {
+                        setSpotEdit({ ...spotEdit, manager: e.target.value.trim() });
+                      }}
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  ) : null}
+                </div>
               </div>
-              <div className='mb-5'>
-                <label htmlFor='address'>住所</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.address}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, address: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='manager'>担当者</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.manager}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, manager: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='tel'>電話番号</label>
-                {spot ? (
-                  <input
-                    type='text'
-                    value={spotEdit.tel}
-                    onChange={(e) => {
-                      setSpotEdit({ ...spotEdit, manager: e.target.value.trim() });
-                    }}
-                    className='w-full p-2 rounded-md'
-                  />
-                ) : null}
-              </div>
-              <div className='mb-5'>
-                <label htmlFor='email'>メールアドレス</label>
+              <div className='mb-4'>
+                <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
+                  メールアドレス
+                </label>
                 {spot ? (
                   <input
                     type='text'
@@ -545,7 +493,7 @@ const SpotsEdit: NextPage<Spot> = () => {
                     onChange={(e) => {
                       setSpotEdit({ ...spotEdit, manager: e.target.value.trim() });
                     }}
-                    className='w-full p-2 rounded-md'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
                   />
                 ) : null}
               </div>
@@ -558,9 +506,9 @@ const SpotsEdit: NextPage<Spot> = () => {
                 編集する
               </button>
             </div>
-            <Toaster />
           </div>
-        </div>
+          <Toaster />
+        </AdminInfoLayout>
       </>
     );
   }

--- a/src/pages/admins/spots/post/index.tsx
+++ b/src/pages/admins/spots/post/index.tsx
@@ -197,14 +197,12 @@ const SpotsPost: NextPage = () => {
     return (
       <>
         <AdminInfoLayout>
-          <h1 className='font-bold text-3xl mt-12'>スポット投稿</h1>
-          <div className='h-full my-10 px-12 overflow-hidden shadow-lg bg-white'>
+          <h1 className='font-bold text-3xl pt-12'>スポット投稿</h1>
+          <div className='h-full my-10 px-6 sm:px-12 md:px-16 overflow-hidden shadow-lg bg-white'>
             {/* スポット投稿 */}
-            <h2 className='flex mt-5'>
-              スポット画像<p className=''>(最大5枚)</p>
-            </h2>
+            <h2 className='flex mt-12'>スポット画像(最大5枚)</h2>
             {/* {console.log('ファイル', files)} */}
-            <div className='flex flex-wrap items-end mt-6'>
+            <div className='flex flex-wrap items-end'>
               {files && files.length > 0 ? (
                 files.map((file, index) => (
                   <div key={index} className='py-2 px-1'>
@@ -230,87 +228,91 @@ const SpotsPost: NextPage = () => {
             <SpotUploadButton onUpload={handleDrop} loading={uploading} />
             {/* スポット情報 */}
             <div>
-              <h2 className='mt-10 '>スポット情報</h2>
+              <h2 className='mt-10'>スポット情報</h2>
               <div className='text-xs'>
-                <div className='mb-5'>
-                  <label htmlFor='name' className='flex justify-start pt-10 pb-3'>
-                    スポット名
-                  </label>
-                  <input
-                    type='text'
-                    value={spotPost.name}
-                    onChange={(e) => {
-                      setSpotPost({ ...spotPost, name: e.target.value.trim() });
-                    }}
-                    placeholder='穴水町'
-                    className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
-                  />
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='title' className='flex justify-start pt-10 pb-3'>
-                    スポットタイトル
-                  </label>
-                  <input
-                    type='text'
-                    value={spotPost.title}
-                    onChange={(e) => {
-                      setSpotPost({ ...spotPost, title: e.target.value.trim() });
-                    }}
-                    placeholder='自然豊かな穴水町での生活を体験してみませんか'
-                    className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                  />
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='prefectures_name' className='flex justify-start pt-10 pb-3'>
-                    都道府県名
-                  </label>
-                  {/* {console.log(prefecturesCreatedAt)} */}
-                  {prefecturesCreatedAt.length == 0 ? null : (
-                    <select
-                      value={spotPost.prefecture_id}
+                <div className='flex gap-8'>
+                  <div className='mb-4'>
+                    <label htmlFor='name' className='flex justify-start pt-10 pb-3'>
+                      スポット名
+                    </label>
+                    <input
+                      type='text'
+                      value={spotPost.name}
                       onChange={(e) => {
-                        setSpotPost({ ...spotPost, prefecture_id: e.target.value.trim() });
+                        setSpotPost({ ...spotPost, name: e.target.value.trim() });
                       }}
-                      className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                    >
-                      {/* {console.log(spotPost.prefecture_id)} */}
-                      <option value='prefectures_select'>都道府県を選択</option>
-                      {prefecturesCreatedAt.map((value, index) => (
-                        <option key={index} value={value['prefectures_index']}>
-                          {value['prefectures_name']}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </div>
-                <div className='mb-5'>
-                  <label htmlFor='system' className='flex justify-start pt-10 pb-3'>
-                    制度名
-                  </label>
-                  {systemsCreatedAt.length == 0 ? null : (
-                    <select
-                      value={spotPost.system_id}
+                      placeholder='穴水町'
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  </div>
+                  <div className='mb-4'>
+                    <label htmlFor='title' className='flex justify-start pt-10 pb-3'>
+                      スポットタイトル
+                    </label>
+                    <input
+                      type='text'
+                      value={spotPost.title}
                       onChange={(e) => {
-                        setSpotPost({ ...spotPost, system_id: e.target.value.trim() });
+                        setSpotPost({ ...spotPost, title: e.target.value.trim() });
                       }}
-                      className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                    >
-                      {/* {console.log(spotPost.system_id)} */}
-                      <option value='systems_select'>制度を選択</option>
-                      {systemsCreatedAt.map((value, index) => (
-                        <option key={index} value={value['systems_index']}>
-                          {value['systems_name']}
-                        </option>
-                      ))}
-                    </select>
-                  )}
+                      placeholder='自然豊かな穴水町での生活を体験してみませんか'
+                      className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                    />
+                  </div>
+                </div>
+                <div className='flex gap-8'>
+                  <div className='mb-4'>
+                    <label htmlFor='prefectures_name' className='flex justify-start pt-10 pb-3'>
+                      都道府県名
+                    </label>
+                    {/* {console.log(prefecturesCreatedAt)} */}
+                    {prefecturesCreatedAt.length == 0 ? null : (
+                      <select
+                        value={spotPost.prefecture_id}
+                        onChange={(e) => {
+                          setSpotPost({ ...spotPost, prefecture_id: e.target.value.trim() });
+                        }}
+                        className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                      >
+                        {/* {console.log(spotPost.prefecture_id)} */}
+                        <option value='prefectures_select'>都道府県を選択</option>
+                        {prefecturesCreatedAt.map((value, index) => (
+                          <option key={index} value={value['prefectures_index']}>
+                            {value['prefectures_name']}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                  <div className='mb-4'>
+                    <label htmlFor='system' className='flex justify-start pt-10 pb-3'>
+                      制度名
+                    </label>
+                    {systemsCreatedAt.length == 0 ? null : (
+                      <select
+                        value={spotPost.system_id}
+                        onChange={(e) => {
+                          setSpotPost({ ...spotPost, system_id: e.target.value.trim() });
+                        }}
+                        className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                      >
+                        {/* {console.log(spotPost.system_id)} */}
+                        <option value='systems_select'>制度を選択</option>
+                        {systemsCreatedAt.map((value, index) => (
+                          <option key={index} value={value['systems_index']}>
+                            {value['systems_name']}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
             {/* スポット説明 */}
             <h2 className='mt-10'>スポット説明</h2>
             <div className='text-xs'>
-              <div className='mb-5'>
+              <div className='mb-4'>
                 <label htmlFor='appeal' className='flex justify-start pt-10 pb-3'>
                   アピールポイント
                 </label>
@@ -324,75 +326,92 @@ const SpotsPost: NextPage = () => {
             そんな穴水町の暮らしぶりを気軽に体験して頂けるように「短期移住体験住宅」をご用意いたしました。
             空港や駅へのアクセスも良く、暮らしやすい場所で移住体験ができます。
             田舎への移住をお考えの方はこの機会にぜひご利用下さい。'
-                  className='w-full h-24  p-2 rounded-md border-2 placeholder-gray-500'
+                  className='w-full h-24 p-2 rounded-md border-2 placeholder-gray-500'
                 />
               </div>
             </div>
             {/* スポット詳細 */}
             <h2 className='mt-10'>スポット詳細</h2>
             <div className='text-xs'>
-              <div className='mb-5'>
-                <label htmlFor='area' className='flex justify-start pt-10 pb-3'>
-                  物件所在地
-                </label>
-                <input
-                  type='text'
-                  value={spotPost.area}
-                  onChange={(e) => {
-                    setSpotPost({ ...spotPost, area: e.target.value.trim() });
-                  }}
-                  placeholder='石川県穴水町'
-                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                />
+              <div className='flex gap-8'>
+                <div className='mb-4'>
+                  <label htmlFor='area' className='flex justify-start pt-10 pb-3'>
+                    物件所在地
+                  </label>
+                  <input
+                    type='text'
+                    value={spotPost.area}
+                    onChange={(e) => {
+                      setSpotPost({ ...spotPost, area: e.target.value.trim() });
+                    }}
+                    placeholder='石川県穴水町'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                  />
+                </div>
+                <div className='mb-4'>
+                  <label htmlFor='スポット画像' className='flex justify-start pt-10 pb-3'>
+                    利用料金
+                  </label>
+                  <input
+                    type='text'
+                    value={spotPost.usage_fee}
+                    onChange={(e) => {
+                      setSpotPost({ ...spotPost, usage_fee: e.target.value.trim() });
+                    }}
+                    placeholder='無料'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                  />
+                </div>
               </div>
-
-              <div className='mb-5'>
+              <div className='mb-4'>
                 <label htmlFor='スポット画像' className='flex justify-start pt-10 pb-3'>
-                  利用料金
+                  利用期間
                 </label>
                 <input
                   type='text'
-                  value={spotPost.usage_fee}
+                  value={spotPost.term}
                   onChange={(e) => {
-                    setSpotPost({ ...spotPost, usage_fee: e.target.value.trim() });
+                    setSpotPost({ ...spotPost, term: e.target.value.trim() });
                   }}
-                  placeholder='無料'
-                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
+                  placeholder='最長７泊８日'
+                  className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
                 />
               </div>
             </div>
             {/* お問い合わせ */}
             <h2 className='mt-10'>お問い合わせ先</h2>
             <div className='text-xs'>
-              <div className='mb-5'>
-                <label htmlFor='manager' className='flex justify-start pt-10 pb-3'>
-                  担当者
-                </label>
-                <input
-                  type='text'
-                  value={spotPost.manager}
-                  onChange={(e) => {
-                    setSpotPost({ ...spotPost, manager: e.target.value.trim() });
-                  }}
-                  placeholder='穴水町観光交流課'
-                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                />
+              <div className='flex gap-8'>
+                <div className='mb-4'>
+                  <label htmlFor='manager' className='flex justify-start pt-10 pb-3'>
+                    担当者
+                  </label>
+                  <input
+                    type='text'
+                    value={spotPost.manager}
+                    onChange={(e) => {
+                      setSpotPost({ ...spotPost, manager: e.target.value.trim() });
+                    }}
+                    placeholder='穴水町観光交流課'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                  />
+                </div>
+                <div className='mb-4'>
+                  <label htmlFor='tel' className='flex justify-start pt-10 pb-3'>
+                    電話番号
+                  </label>
+                  <input
+                    type='text'
+                    value={spotPost.tel}
+                    onChange={(e) => {
+                      setSpotPost({ ...spotPost, tel: e.target.value.trim() });
+                    }}
+                    placeholder='0768-52-3671'
+                    className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
+                  />
+                </div>
               </div>
-              <div className='mb-5'>
-                <label htmlFor='tel' className='flex justify-start pt-10 pb-3'>
-                  電話番号
-                </label>
-                <input
-                  type='text'
-                  value={spotPost.tel}
-                  onChange={(e) => {
-                    setSpotPost({ ...spotPost, tel: e.target.value.trim() });
-                  }}
-                  placeholder='0768-52-3671'
-                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
-                />
-              </div>
-              <div className='mb-5'>
+              <div className='mb-4'>
                 <label htmlFor='email' className='flex justify-start pt-10 pb-3'>
                   メールアドレス
                 </label>
@@ -403,7 +422,7 @@ const SpotsPost: NextPage = () => {
                     setSpotPost({ ...spotPost, email: e.target.value.trim() });
                   }}
                   placeholder='test@gmai.com'
-                  className='w-[280px] sm:w-[300px] md:w-[380px] max-w-full p-2  rounded-md border-2 placeholder-gray-500'
+                  className='w-[150px] sm:w-[250px] md:w-[325px] max-w-full p-2 rounded-md border-2 placeholder-gray-500'
                 />
               </div>
             </div>


### PR DESCRIPTION
# レイアウト変更

## 確認ページ
- プロフィール編集
- スポット投稿
- スポット編集

## 変更箇所
- ヘッダー
- フォームのレイアウト
- 背景やフォームの色を変更

## 確認方法(figmaリメイクデザイン)
https://www.figma.com/file/Yx2kv1ZoPKrX2gngVlY6Tj/remake-PF?node-id=0%3A1

## issue
- #121 
