### PR TITLE
⚡️スライドの無限ループ設定とユーザー画面へ戻るリンク設置

### DIFF
--- a/src/components/Carousel/AboutCarousel/index.tsx
+++ b/src/components/Carousel/AboutCarousel/index.tsx
@@ -29,6 +29,7 @@ export const AboutCarousel: VFC = () => {
         pagination={true}
         mousewheel={true}
         keyboard={true}
+        loop={true}
         autoplay={{
           delay: 5000,
           disableOnInteraction: true,

--- a/src/components/Layout/AdminInfoLayout/index.tsx
+++ b/src/components/Layout/AdminInfoLayout/index.tsx
@@ -134,6 +134,11 @@ export const AdminInfoLayout: VFC<Props> = (props) => {
                         スポット編集
                       </a>
                     </Link>
+                    <Link href='/' passHref>
+                      <a className='text-xs hover:bg-blue-100 py-8 pl-4 lg:text-sm border-b-2 border-gray-200 '>
+                        ホーム画面
+                      </a>
+                    </Link>
                     <a className='text-xs hover:bg-blue-100 py-8 pl-4 lg:text-sm border-gray-200 '>
                       <button onClick={HandleLogout}>ログアウト</button>
                     </a>


### PR DESCRIPTION
## 対応内容
- スライドの無限ループ設定
- ユーザー画面へ戻るリンク設置

## 対応箇所
- アバウトページのカルーセルが無限にスライドする
- 管理画面のユーザーアイコンクリック後にユーザー画面へ戻るリンク設置


